### PR TITLE
ForwardRates para CompoundedOvernightRateCashflow2 y corrección de ac…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ QC_DVE_CORE/cmake-build-release-centos8/
 QC_DVE_CORE/cmake-build-docker-redhat85-amd64-py311/
 QC_DVE_CORE/cmake-build-centos/
 cmake-build-redhat85-py39/
+QC_DVE_CORE/build_20240412

--- a/QC_DVE_CORE/CMakeLists.txt
+++ b/QC_DVE_CORE/CMakeLists.txt
@@ -8,11 +8,11 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 add_library(QC_DVE_CORE STATIC "")
 set_target_properties(QC_DVE_CORE PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+set(Python_ROOT_DIR /users/adiazv/.pyenv/versions/3.12.1)
 add_subdirectory(pybind11)
 pybind11_add_module(qcfinancial source/qcf_binder.cpp)
 target_link_libraries(qcfinancial PRIVATE QC_DVE_CORE)
 target_include_directories(qcfinancial PRIVATE include)
-
 # add_executable(QC_DVE_CORE_TESTS Tests/IcpClpCashflow3Tests.cpp)
 # add_executable(manual_tests include/QcfinancialPybind11Helpers.h)
 

--- a/QC_DVE_CORE/compile_one.sh
+++ b/QC_DVE_CORE/compile_one.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pyenv global 3.12.1
+python setup.py bdist_wheel

--- a/QC_DVE_CORE/include/cashflows/CompoundedOvernightRateCashflow2.h
+++ b/QC_DVE_CORE/include/cashflows/CompoundedOvernightRateCashflow2.h
@@ -208,7 +208,7 @@ namespace QCode::Financial {
 
         double _calculateInterest(double rateValue, QCDate &fecha);
 
-        double _getRateValue() const;
+        [[nodiscard]] double _getRateValue() const;
 
 
     };

--- a/QC_DVE_CORE/include/cashflows/IborCashflow.h
+++ b/QC_DVE_CORE/include/cashflows/IborCashflow.h
@@ -83,7 +83,7 @@ namespace QCode
 						 double spread,
 						 double gearing);
 
-            virtual std::string getType() const;
+            [[nodiscard]] virtual std::string getType() const;
 
 			/**
 			 * @fn	double IborCashflow::amount();
@@ -97,6 +97,30 @@ namespace QCode
 			 */
 			double amount() override;
 
+            /**
+ * @fn	shared_ptr<QCCurrency> IborCashflow::ccy();
+ *
+ * @brief	Gets the ccy
+ *
+ * @author	Alvaro Díaz V.
+ * @date	29/09/2017
+ *
+ * @return	A shared_ptr&lt;QCCurrency&gt;
+ */
+            shared_ptr<QCCurrency> ccy() override;
+
+            /**
+ * @fn	QCDate IborCashflow::date();
+ *
+ * @brief	Gets the date
+ *
+ * @author	Alvaro Díaz V.
+ * @date	29/09/2017
+ *
+ * @return	A QCDate.
+ */
+            QCDate date() override;
+
 
             virtual double settlementAmount();
 
@@ -106,29 +130,6 @@ namespace QCode
 
 			[[nodiscard]] std::string getInterestRateIndexCode() const;
 
-			/**
-			 * @fn	shared_ptr<QCCurrency> IborCashflow::ccy();
-			 *
-			 * @brief	Gets the ccy
-			 *
-			 * @author	Alvaro Díaz V.
-			 * @date	29/09/2017
-			 *
-			 * @return	A shared_ptr&lt;QCCurrency&gt;
-			 */
-			shared_ptr<QCCurrency> ccy() override;
-
-			/**
-			 * @fn	QCDate IborCashflow::date();
-			 *
-			 * @brief	Gets the date
-			 *
-			 * @author	Alvaro Díaz V.
-			 * @date	29/09/2017
-			 *
-			 * @return	A QCDate.
-			 */
-			QCDate date() override;
 
 			/**
 			 * @fn	QCDate IborCashflow::getStartDate();
@@ -140,7 +141,7 @@ namespace QCode
 			 *
 			 * @return	The start date.
 			 */
-			QCDate getStartDate() const;
+			[[nodiscard]] QCDate getStartDate() const;
 
 			/**
 			 * @fn	QCDate IborCashflow::getEndDate() const;
@@ -152,7 +153,7 @@ namespace QCode
 			 *
 			 * @return	The end date.
 			 */
-			QCDate getEndDate() const;
+			[[nodiscard]] QCDate getEndDate() const;
 
 			/**
 			* @fn	    QCDate IborCashflow::getFixingDate();
@@ -164,7 +165,10 @@ namespace QCode
 			*
 			* @return	QCDate;
 			*/
-			QCDate getFixingDate() const;
+			[[nodiscard]] QCDate getFixingDate() const;
+
+            [[nodiscard]] QCDate getSettlementDate() const;
+
 
 			/**
 			 * @fn	QCDate IborCashflow::getIndexStartDate() const;
@@ -212,7 +216,7 @@ namespace QCode
 			 *
 			 * @return	The nominal.
 			 */
-			double getNominal() const;
+			[[nodiscard]] double getNominal() const;
 
 			/**
 			* @fn	void iborCashflow::setAmortization(double amortization);
@@ -236,7 +240,7 @@ namespace QCode
 			 *
 			 * @return	The amortization.
 			 */
-			double getAmortization() const;
+			[[nodiscard]] double getAmortization() const;
 
 			/**
 			* @fn	void iborCashflow::setInterestRateValue(double value);
@@ -260,7 +264,7 @@ namespace QCode
 			 *
 			 * @return	The interest rate value.
 			 */
-			double getInterestRateValue() const;
+			[[nodiscard]] double getInterestRateValue() const;
 
 			/**
 			 * @fn	double IborCashflow::accruedInterest(const QCDate& valueDate);
@@ -288,6 +292,12 @@ namespace QCode
 			 */
 			shared_ptr<IborCashflowWrapper> wrap();
 
+            void setForwardRateWfDerivatives(const std::vector<double>& der);
+
+            [[nodiscard]] std::vector<double> getAmountDerivatives() const;
+
+            [[nodiscard]] std::shared_ptr<InterestRateIndex> getInterestRateIndex() const;
+
 			/**
 			 * @fn	virtual IborCashflow::~IborCashflow();
 			 *
@@ -296,7 +306,7 @@ namespace QCode
 			 * @author	Alvaro Díaz V.
 			 * @date	29/09/2017
 			 */
-			virtual ~IborCashflow();
+			~IborCashflow() override;
 
 		protected:
 			/** @brief	The interest rate index value */
@@ -366,7 +376,18 @@ namespace QCode
 			 * @return	True if it succeeds, false if it fails.
 			 */
 			bool _validate();
-		};
+
+            /** @brief	Stores de derivatives of forward rate wealth factor with respect to rates belonging to zero
+             * coupon curve.
+           */
+            std::vector<double> _forwardRateWfDerivatives;
+
+            /** @brief	Stores de derivatives of amount() with respect to rates belonging to zero
+            * coupon curve.
+            */
+            std::vector<double> _amountDerivatives;
+
+        };
 
 	}
 }

--- a/QC_DVE_CORE/include/cashflows/IborCashflow2.h
+++ b/QC_DVE_CORE/include/cashflows/IborCashflow2.h
@@ -46,13 +46,15 @@ namespace QCode
                     double spread,
                     double gearing);
 
+            string getType() const override;
+
             double amount() override;
 
             shared_ptr<QCCurrency> ccy() override;
 
             QCDate date() override;
 
-            string getType() const override;
+
 
             shared_ptr<QCCurrency> getInitialCcy() const override;
 

--- a/QC_DVE_CORE/include/present_value/ForwardRates.h
+++ b/QC_DVE_CORE/include/present_value/ForwardRates.h
@@ -50,6 +50,36 @@
                 return std::make_shared<IborCashflow2>(iborCashflow_);
             }
 
+            std::shared_ptr<IborCashflow> setRateIborCashflow1(
+                    const QCDate &valuationDate,
+                    Cashflow &iborCashflow,
+                    ZeroCouponCurve &curve) {
+                auto iborCashflow_ = dynamic_cast<IborCashflow &>(iborCashflow);
+                std::vector<double> derivatives;
+                derivatives.resize(curve.getLength());
+                for (size_t i = 0; i < curve.getLength(); ++i) {
+                    derivatives.at(i) = 0.0;
+                }
+                iborCashflow_.setForwardRateWfDerivatives(derivatives);
+                auto fixingDate = iborCashflow_.getFixingDate();
+                if (valuationDate > fixingDate) {
+                    return std::make_shared<IborCashflow>(iborCashflow_);
+                }
+                QCDate fecha1 = iborCashflow_.getIndexStartDate();
+                QCDate fecha2 = iborCashflow_.getIndexEndDate();
+                long t1 = valuationDate.dayDiff(fecha1);
+                long t2 = valuationDate.dayDiff(fecha2);
+                auto iborRate = iborCashflow_.getInterestRateIndex()->getRate();
+                auto tasaForward = curve.getForwardRateWithRate(iborRate, t1, t2);
+                for (size_t i = 0; i < curve.getLength(); ++i) {
+                    derivatives.at(i) = curve.fwdWfDerivativeAt(i);
+                }
+                iborCashflow_.setInterestRateValue(tasaForward);
+                iborCashflow_.setForwardRateWfDerivatives(derivatives);
+                auto plazo = valuationDate.dayDiff(iborCashflow_.getSettlementDate());
+                return std::make_shared<IborCashflow>(iborCashflow_);
+            }
+
 
             void setRatesIborLeg(
                     const QCDate &valuationDate,
@@ -58,6 +88,17 @@
                 _derivatives2.resize(iborLeg.size(), vector<double>(curve.getLength(), 0.0));
                 for (size_t i = 0; i < iborLeg.size(); ++i) {
                     auto cashflow = setRateIborCashflow(valuationDate, *(iborLeg.getCashflowAt(i)), curve);
+                    iborLeg.setCashflowAt(cashflow, i);
+                }
+            }
+
+            void setRatesIborLeg1(
+                    const QCDate &valuationDate,
+                    Leg &iborLeg,
+                    ZeroCouponCurve &curve) {
+                _derivatives2.resize(iborLeg.size(), vector<double>(curve.getLength(), 0.0));
+                for (size_t i = 0; i < iborLeg.size(); ++i) {
+                    auto cashflow = setRateIborCashflow1(valuationDate, *(iborLeg.getCashflowAt(i)), curve);
                     iborLeg.setCashflowAt(cashflow, i);
                 }
             }
@@ -74,6 +115,26 @@
                     // Calcular el fixing
                     auto accruedFixing = initialCashflow->accruedFixing(valuationDate, fixings);
                     auto cashflow = setRateCompoundedOvernightCashflow(
+                            valuationDate,
+                            accruedFixing,
+                            *initialCashflow,
+                            curve);
+                    compoundedONLeg.setCashflowAt(cashflow, i);
+                }
+            }
+
+            void setRatesCompoundedOvernightLeg2(
+                    const QCDate &valuationDate,
+                    Leg &compoundedONLeg,
+                    ZeroCouponCurve &curve,
+                    const TimeSeries& fixings) {
+                _derivatives2.resize(compoundedONLeg.size(), vector<double>(curve.getLength(), 0.0));
+                for (size_t i = 0; i < compoundedONLeg.size(); ++i) {
+                    auto initialCashflow = std::dynamic_pointer_cast<CompoundedOvernightRateCashflow2>(compoundedONLeg.getCashflowAt(i));
+
+                    // Calcular el fixing
+                    auto accruedFixing = initialCashflow->accruedFixing(valuationDate, fixings);
+                    auto cashflow = setRateCompoundedOvernightCashflow2(
                             valuationDate,
                             accruedFixing,
                             *initialCashflow,
@@ -156,6 +217,81 @@
                     return std::make_shared<CompoundedOvernightRateCashflow>(compoundedONRateCashflow_);
                 }
             }
+
+            std::shared_ptr<CompoundedOvernightRateCashflow2> setRateCompoundedOvernightCashflow2(
+                    const QCDate &valuationDate,
+                    double accruedFixing,
+                    Cashflow &compoundedONRateCashflow,
+                    ZeroCouponCurve &curve) {
+                std::vector<double> zeroDerivatives(curve.getLength(), 0.0);
+
+                auto compoundedONRateCashflow_ = dynamic_cast<CompoundedOvernightRateCashflow2 &>(compoundedONRateCashflow);
+                auto notional_ = compoundedONRateCashflow_.getNotional();
+
+                if (valuationDate >= compoundedONRateCashflow_.getEndDate())
+                {
+                    compoundedONRateCashflow_.setAmountDerivatives(zeroDerivatives);
+                    compoundedONRateCashflow_.setInitialDateWf(1.0);
+                    compoundedONRateCashflow_.getInterestRateIndex()->setRateValue(accruedFixing);
+                    auto t = compoundedONRateCashflow_.getStartDate().dayDiff(compoundedONRateCashflow_.getEndDate());
+                    auto endDateWf = compoundedONRateCashflow_.getInterestRateIndex()->getRate().wf(t);
+                    compoundedONRateCashflow_.setEndDateWf(endDateWf);
+                    return std::make_shared<CompoundedOvernightRateCashflow2>(compoundedONRateCashflow_);
+
+                }
+                else if ((compoundedONRateCashflow_.getStartDate() < valuationDate) &&
+                         (valuationDate < compoundedONRateCashflow_.getEndDate()))
+                {
+                    compoundedONRateCashflow_.setInitialDateWf(1.0);
+                    auto t1 = compoundedONRateCashflow_.getStartDate().dayDiff(valuationDate);
+                    auto t2 = valuationDate.dayDiff(compoundedONRateCashflow_.getEndDate());
+                    compoundedONRateCashflow_.getInterestRateIndex()->setRateValue(accruedFixing);
+                    auto accruedWf = compoundedONRateCashflow_.getInterestRateIndex()->getRate().wf(t1);
+                    compoundedONRateCashflow_.setEndDateWf(accruedWf / curve.getDiscountFactorAt(t2));
+                    for (size_t i = 0; i < curve.getLength(); ++i) {
+                        zeroDerivatives.at(i) = notional_ * accruedWf * curve.wfDerivativeAt(i);
+                    }
+                    compoundedONRateCashflow_.setAmountDerivatives(zeroDerivatives);
+                    return std::make_shared<CompoundedOvernightRateCashflow2>(compoundedONRateCashflow_);
+                }
+                else if (compoundedONRateCashflow_.getStartDate() == valuationDate)
+                {
+                    compoundedONRateCashflow_.setInitialDateWf(1.0);
+                    auto t = valuationDate.dayDiff(compoundedONRateCashflow_.getEndDate());
+                    auto endDateWf = 1.0 / curve.getDiscountFactorAt(t);
+                    compoundedONRateCashflow_.setEndDateWf(endDateWf);
+                    for (size_t i = 0; i < curve.getLength(); ++i) {
+                        zeroDerivatives.at(i) = notional_ * curve.wfDerivativeAt(i);
+                    }
+                    compoundedONRateCashflow_.setAmountDerivatives(zeroDerivatives);
+                    return std::make_shared<CompoundedOvernightRateCashflow2>(compoundedONRateCashflow_);
+                }
+                else
+                {
+                    auto t1 = valuationDate.dayDiff(compoundedONRateCashflow_.getStartDate());
+                    compoundedONRateCashflow_.setInitialDateWf(1.0 / curve.getDiscountFactorAt(t1));
+                    vector<double> startDateDerivatives(curve.getLength(), 0.0);
+                    for (size_t i = 0; i < curve.getLength(); ++i) {
+                        startDateDerivatives.at(i) = curve.wfDerivativeAt(i);
+                    }
+
+                    auto t2 = valuationDate.dayDiff(compoundedONRateCashflow_.getEndDate());
+                    compoundedONRateCashflow_.setEndDateWf(1.0 / curve.getDiscountFactorAt(t2));
+                    vector<double> endDateDerivatives(curve.getLength(), 0.0);
+                    for (size_t i = 0; i < curve.getLength(); ++i) {
+                        endDateDerivatives.at(i) = curve.wfDerivativeAt(i);
+                    }
+                    for (size_t i = 0; i < curve.getLength(); ++i) {
+                        zeroDerivatives.at(i) = notional_ * (endDateDerivatives.at(i) / curve.getDiscountFactorAt(t1) -
+                                                             startDateDerivatives.at(i) / curve.getDiscountFactorAt(t2)) *
+                                                std::pow(curve.getDiscountFactorAt(t1), 2.0);
+                    }
+                    compoundedONRateCashflow_.setAmountDerivatives(zeroDerivatives);
+
+                    return std::make_shared<CompoundedOvernightRateCashflow2>(compoundedONRateCashflow_);
+                }
+            }
+
 
 
             std::shared_ptr<IcpClpCashflow2> setRateIcpClpCashflow(

--- a/QC_DVE_CORE/setup.py
+++ b/QC_DVE_CORE/setup.py
@@ -133,7 +133,7 @@ class CMakeBuild(build_ext):
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="qcfinancial",
-    version="0.8.1",
+    version="0.8.2",
     author="Alvaro Diaz V.",
     author_email="alvaro@efaa.cl",
     description="A Library for Valuation of Linear Interest Rate and FX Derivatives",

--- a/QC_DVE_CORE/source/cashflows/IborCashflow.cpp
+++ b/QC_DVE_CORE/source/cashflows/IborCashflow.cpp
@@ -80,6 +80,10 @@ namespace QCode
             return _fixingDate;
         }
 
+        QCDate  IborCashflow::getSettlementDate() const {
+            return _settlementDate;
+        }
+
 
         QCDate IborCashflow::getIndexStartDate()
         {
@@ -124,6 +128,22 @@ namespace QCode
             _calculateInterest();
         }
 
+        void QCode::Financial::IborCashflow::setForwardRateWfDerivatives(const std::vector<double> &der) {
+            _forwardRateWfDerivatives.resize(der.size());
+            for (size_t i = 0; i < der.size(); ++i) {
+                _forwardRateWfDerivatives.at(i) = der.at(i);
+            }
+        }
+
+        std::vector<double> QCode::Financial::IborCashflow::getAmountDerivatives() const {
+            return _amountDerivatives;
+        }
+
+
+        std::shared_ptr<InterestRateIndex> QCode::Financial::IborCashflow::getInterestRateIndex() const {
+            return _index;
+        }
+
 
         double IborCashflow::getInterestRateValue() const
         {
@@ -148,21 +168,22 @@ namespace QCode
 
         shared_ptr<IborCashflowWrapper> IborCashflow::wrap()
         {
-            IborCashflowWrapper tup = std::make_tuple(_startDate,
-                                                      _endDate,
-                                                      _fixingDate,
-                                                      _settlementDate,
-                                                      _nominal,
-                                                      _amortization,
-                                                      _interest,
-                                                      _doesAmortize,
-                                                      amount(),
-                                                      _currency,
-                                                      _index->getCode(),
-                                                      _index->getRate(),
-                                                      _spread,
-                                                      _gearing,
-                                                      _rateValue);
+            IborCashflowWrapper tup = std::make_tuple(
+                    _startDate,
+                    _endDate,
+                    _fixingDate,
+                    _settlementDate,
+                    _nominal,
+                    _amortization,
+                    _interest,
+                    _doesAmortize,
+                    amount(),
+                    _currency,
+                    _index->getCode(),
+                    _index->getRate(),
+                    _spread,
+                    _gearing,
+                    _rateValue);
 
             return std::make_shared<IborCashflowWrapper>(tup);
         }

--- a/QC_DVE_CORE/source/cashflows/IborCashflow2.cpp
+++ b/QC_DVE_CORE/source/cashflows/IborCashflow2.cpp
@@ -190,7 +190,7 @@ double QCode::Financial::IborCashflow2::accruedInterest(const QCDate &fecha) {
 
 double QCode::Financial::IborCashflow2::accruedInterest(const QCDate &fecha,
                                                         const QCode::Financial::TimeSeries &fixings) {
-    if (fecha < _startDate || _endDate >= fecha) {
+    if ((fecha < _startDate) || (_endDate <= fecha)) {
         return 0.0;
     }
     try {

--- a/QC_DVE_CORE/source/qcf_binder.cpp
+++ b/QC_DVE_CORE/source/qcf_binder.cpp
@@ -99,7 +99,7 @@ PYBIND11_MODULE(qcfinancial, m) {
 
         m.def(
                 "id",
-                []() { return "2024-04-01 13:10"; });
+                []() { return "v0.8.1 2024-04-13 08:00"; });
 
         // QCDate
         py::class_<QCDate>(m, "QCDate", R"pbdoc(
@@ -653,7 +653,8 @@ PYBIND11_MODULE(qcfinancial, m) {
                         .def("get_amortization", &qf::IborCashflow::getAmortization)
                         .def("get_type", &qf::IborCashflow::getType)
                         .def("settlement_amount", &qf::IborCashflow::settlementAmount)
-                        .def("settlement_currency", &qf::IborCashflow::settlementCurrency);
+                        .def("settlement_currency", &qf::IborCashflow::settlementCurrency)
+                        .def("get_amount_derivatives", &qf::IborCashflow::getAmountDerivatives);
 
         m.def("show", py::overload_cast<const std::shared_ptr<qf::IborCashflow> &>(&show));
 
@@ -1648,6 +1649,7 @@ PYBIND11_MODULE(qcfinancial, m) {
         py::class_<qf::ForwardRates>(m, "ForwardRates")
                         .def(py::init<>())
                         .def("set_rate_ibor_cashflow", &qf::ForwardRates::setRateIborCashflow)
+                        .def("set_rate_ibor_cashflow1", &qf::ForwardRates::setRateIborCashflow1)
                         .def("set_rate_icp_clp_cashflow", &qf::ForwardRates::setRateIcpClpCashflow)
                         .def("set_rate_icp_clp_cashflow2", &qf::ForwardRates::setRateIcpClpCashflow2)
                         .def("set_rate_overnight_index_cashflow", &qf::ForwardRates::setRateOvernightIndexCashflow)
@@ -1655,11 +1657,15 @@ PYBIND11_MODULE(qcfinancial, m) {
                         .def("set_rates_icp_clp_leg2", &qf::ForwardRates::setRatesIcpClpLeg2)
                         .def("set_rates_overnight_index_leg", &qf::ForwardRates::setRatesOvernightIndexLeg)
                         .def("set_rates_ibor_leg", &qf::ForwardRates::setRatesIborLeg)
+                        .def("set_rates_ibor_leg1", &qf::ForwardRates::setRatesIborLeg1)
                         .def("set_rate_icp_clf_cashflow", &qf::ForwardRates::setRateIcpClfCashflow)
                         .def("set_rates_icp_clf_leg", &qf::ForwardRates::setRatesIcpClfLeg)
                         .def("set_rate_compounded_overnight_cashflow",
                              &qf::ForwardRates::setRateCompoundedOvernightCashflow)
-                        .def("set_rates_compounded_overnight_leg", &qf::ForwardRates::setRatesCompoundedOvernightLeg);
+                        .def("set_rate_compounded_overnight_cashflow2",
+                             &qf::ForwardRates::setRateCompoundedOvernightCashflow2)
+                        .def("set_rates_compounded_overnight_leg", &qf::ForwardRates::setRatesCompoundedOvernightLeg)
+                        .def("set_rates_compounded_overnight_leg2", &qf::ForwardRates::setRatesCompoundedOvernightLeg2);
 
 
 #ifdef VERSION_INFO


### PR DESCRIPTION
Los métodos para calcular las forward rates de los CompoundedOvernightRateCashflow2 no estaban implementados, ahora lo están. En accrued_fixing(QCDate, TimeSeries) la lógica de cupón vigente tenía un error y retornaba intereses iguales a 0 para cupones vigentes.